### PR TITLE
Fix site links and styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.hugo_build.lock

--- a/docs/blog/first-post/index.html
+++ b/docs/blog/first-post/index.html
@@ -4,16 +4,16 @@
     <meta charset="UTF-8">
     <title>First Post</title>
     <meta name="description" content="Introductory post">
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="/framzn/style.css">
 </head>
 <body>
     <nav>
         
-        <a href="/">Home</a>
+        <a href="/framzn/">Home</a>
         
-        <a href="/product/">Product</a>
+        <a href="/framzn/product/">Product</a>
         
-        <a href="/blog/">Blog</a>
+        <a href="/framzn/blog/">Blog</a>
         
     </nav>
     <main>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -4,23 +4,23 @@
     <meta charset="UTF-8">
     <title>Blog</title>
     <meta name="description" content="Latest posts">
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="/framzn/style.css">
 </head>
 <body>
     <nav>
         
-        <a href="/">Home</a>
+        <a href="/framzn/">Home</a>
         
-        <a href="/product/">Product</a>
+        <a href="/framzn/product/">Product</a>
         
-        <a href="/blog/">Blog</a>
+        <a href="/framzn/blog/">Blog</a>
         
     </nav>
     <main>
         
 <ul>
 
-<li><a href="/blog/first-post/">First Post</a></li>
+<li><a href="/framzn/blog/first-post/">First Post</a></li>
 
 </ul>
 

--- a/docs/blog/index.xml
+++ b/docs/blog/index.xml
@@ -2,17 +2,17 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Blog on Framzn Hugo</title>
-    <link>https://talshachar.github.io/blog/</link>
+    <link>https://talshachar.github.io/framzn/blog/</link>
     <description>Recent content in Blog on Framzn Hugo</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
     <lastBuildDate>Mon, 01 Jan 2024 00:00:00 +0000</lastBuildDate>
-    <atom:link href="https://talshachar.github.io/blog/index.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="https://talshachar.github.io/framzn/blog/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>First Post</title>
-      <link>https://talshachar.github.io/blog/first-post/</link>
+      <link>https://talshachar.github.io/framzn/blog/first-post/</link>
       <pubDate>Mon, 01 Jan 2024 00:00:00 +0000</pubDate>
-      <guid>https://talshachar.github.io/blog/first-post/</guid>
+      <guid>https://talshachar.github.io/framzn/blog/first-post/</guid>
       <description>This is the first blog post.</description>
     </item>
   </channel>

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -4,16 +4,16 @@
     <meta charset="UTF-8">
     <title>Categories</title>
     
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="/framzn/style.css">
 </head>
 <body>
     <nav>
         
-        <a href="/">Home</a>
+        <a href="/framzn/">Home</a>
         
-        <a href="/product/">Product</a>
+        <a href="/framzn/product/">Product</a>
         
-        <a href="/blog/">Blog</a>
+        <a href="/framzn/blog/">Blog</a>
         
     </nav>
     <main>

--- a/docs/categories/index.xml
+++ b/docs/categories/index.xml
@@ -2,10 +2,10 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Categories on Framzn Hugo</title>
-    <link>https://talshachar.github.io/categories/</link>
+    <link>https://talshachar.github.io/framzn/categories/</link>
     <description>Recent content in Categories on Framzn Hugo</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <atom:link href="https://talshachar.github.io/categories/index.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="https://talshachar.github.io/framzn/categories/index.xml" rel="self" type="application/rss+xml" />
   </channel>
 </rss>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,25 +5,25 @@
     <meta charset="UTF-8">
     <title>Home</title>
     <meta name="description" content="Welcome to Framzn">
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="/framzn/style.css">
 </head>
 <body>
     <nav>
         
-        <a href="/">Home</a>
+        <a href="/framzn/">Home</a>
         
-        <a href="/product/">Product</a>
+        <a href="/framzn/product/">Product</a>
         
-        <a href="/blog/">Blog</a>
+        <a href="/framzn/blog/">Blog</a>
         
     </nav>
     <main>
         
 <ul>
 
-<li><a href="/blog/">Blog</a></li>
+<li><a href="/framzn/blog/">Blog</a></li>
 
-<li><a href="/product/">Product</a></li>
+<li><a href="/framzn/product/">Product</a></li>
 
 </ul>
 

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -2,24 +2,24 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Home on Framzn Hugo</title>
-    <link>https://talshachar.github.io/</link>
+    <link>https://talshachar.github.io/framzn/</link>
     <description>Recent content in Home on Framzn Hugo</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
     <lastBuildDate>Mon, 01 Jan 2024 00:00:00 +0000</lastBuildDate>
-    <atom:link href="https://talshachar.github.io/index.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="https://talshachar.github.io/framzn/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>First Post</title>
-      <link>https://talshachar.github.io/blog/first-post/</link>
+      <link>https://talshachar.github.io/framzn/blog/first-post/</link>
       <pubDate>Mon, 01 Jan 2024 00:00:00 +0000</pubDate>
-      <guid>https://talshachar.github.io/blog/first-post/</guid>
+      <guid>https://talshachar.github.io/framzn/blog/first-post/</guid>
       <description>This is the first blog post.</description>
     </item>
     <item>
       <title>Product</title>
-      <link>https://talshachar.github.io/product/</link>
+      <link>https://talshachar.github.io/framzn/product/</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
-      <guid>https://talshachar.github.io/product/</guid>
+      <guid>https://talshachar.github.io/framzn/product/</guid>
       <description>Here is where the product details will go.</description>
     </item>
   </channel>

--- a/docs/product/index.html
+++ b/docs/product/index.html
@@ -4,16 +4,16 @@
     <meta charset="UTF-8">
     <title>Product</title>
     <meta name="description" content="Product details">
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="/framzn/style.css">
 </head>
 <body>
     <nav>
         
-        <a href="/">Home</a>
+        <a href="/framzn/">Home</a>
         
-        <a href="/product/">Product</a>
+        <a href="/framzn/product/">Product</a>
         
-        <a href="/blog/">Blog</a>
+        <a href="/framzn/blog/">Blog</a>
         
     </nav>
     <main>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,19 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
-    <loc>https://talshachar.github.io/blog/</loc>
+    <loc>https://talshachar.github.io/framzn/blog/</loc>
     <lastmod>2024-01-01T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>https://talshachar.github.io/blog/first-post/</loc>
+    <loc>https://talshachar.github.io/framzn/blog/first-post/</loc>
     <lastmod>2024-01-01T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>https://talshachar.github.io/</loc>
+    <loc>https://talshachar.github.io/framzn/</loc>
     <lastmod>2024-01-01T00:00:00+00:00</lastmod>
   </url><url>
-    <loc>https://talshachar.github.io/categories/</loc>
+    <loc>https://talshachar.github.io/framzn/categories/</loc>
   </url><url>
-    <loc>https://talshachar.github.io/product/</loc>
+    <loc>https://talshachar.github.io/framzn/product/</loc>
   </url><url>
-    <loc>https://talshachar.github.io/tags/</loc>
+    <loc>https://talshachar.github.io/framzn/tags/</loc>
   </url>
 </urlset>

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -4,16 +4,16 @@
     <meta charset="UTF-8">
     <title>Tags</title>
     
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="/framzn/style.css">
 </head>
 <body>
     <nav>
         
-        <a href="/">Home</a>
+        <a href="/framzn/">Home</a>
         
-        <a href="/product/">Product</a>
+        <a href="/framzn/product/">Product</a>
         
-        <a href="/blog/">Blog</a>
+        <a href="/framzn/blog/">Blog</a>
         
     </nav>
     <main>

--- a/docs/tags/index.xml
+++ b/docs/tags/index.xml
@@ -2,10 +2,10 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Tags on Framzn Hugo</title>
-    <link>https://talshachar.github.io/tags/</link>
+    <link>https://talshachar.github.io/framzn/tags/</link>
     <description>Recent content in Tags on Framzn Hugo</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <atom:link href="https://talshachar.github.io/tags/index.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="https://talshachar.github.io/framzn/tags/index.xml" rel="self" type="application/rss+xml" />
   </channel>
 </rss>

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://talshachar.github.io/'
+baseURL = 'https://talshachar.github.io/framzn/'
 publishDir = 'docs'
 languageCode = 'en-us'
 title = 'Framzn Hugo'


### PR DESCRIPTION
## Summary
- update `baseURL` in `hugo.toml` so links include `/framzn`
- regenerate `docs` with updated URL prefix
- ignore Hugo build lock file

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y hugo`
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_685130c5bfb8832e9bf6bbde614229b1