### PR TITLE
Add holster affiliate site

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,10 @@
 +++
-title = "Home"
-description = "Welcome to Framzn"
+title = "Front Line Model 38 Tuckable IWB Holster"
+description = "Tuckable IWB Kydex holster for deep concealed carry"
 +++
 
-Welcome to **Framzn**, your source for product reviews and more.
+Welcome to our affiliate site featuring the **Front Line Model 38 Tuckable IWB Holster**. This rugged Kydex holster allows deep concealment even when you have your shirt tucked in. Stay discreet and secure while carrying your favorite handgun.
+
+![Front Line Model 38](https://via.placeholder.com/600x400?text=Holster)
+
+<a href="#" class="buy-button">Buy on Amazon</a>

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,6 +1,18 @@
 +++
 title = "Blog"
-description = "Latest posts"
+description = "Articles on concealed carry and tuckable holsters"
 +++
 
-Welcome to the blog.
+Below are some upcoming articles for concealed carry enthusiasts:
+
+- [5 Best Tuckable IWB Holsters for Concealed Carry](#)
+- [How to Conceal Carry with a Tucked Shirt](#)
+- [Choosing the Right Belt Clip for Your IWB Holster](#)
+- [Maintaining Your Kydex Holster](#)
+- [Adjusting Cant and Retention on Tuckable Holsters](#)
+- [Comfort Tips for All-Day Concealed Carry](#)
+- [Holster Compatibility: What Fits Your Handgun](#)
+- [Pros and Cons of Appendix Carry](#)
+- [Summer Concealed Carry Solutions](#)
+- [The Importance of Trigger Protection](#)
+- [How to Safely Practice Your Draw](#)

--- a/content/product/index.md
+++ b/content/product/index.md
@@ -1,6 +1,19 @@
 +++
-title = "Product"
-description = "Product details"
+title = "Front Line Model 38 Tuckable IWB Holster Overview"
+description = "Detailed look at the Front Line Model 38 tuckable concealed carry holster"
 +++
 
-Here is where the product details will go.
+## Overview
+The **Front Line Model 38 Tuckable IWB Holster** is designed for discreet concealed carry. Its tuckable clip lets you hide the holster under a tucked shirt while keeping your firearm accessible and secure.
+
+## Features
+- **Tuckable Clip** – cover the holster completely even with your shirt tucked in.
+- **Kydex Material** – durable and rigid for consistent retention.
+- **Adjustable Cant & Retention** – set your preferred draw angle and tightness.
+- **Comfort Design** – slim profile engineered for all-day wear.
+- **Compatibility** – fits popular models like Glock 19, Sig P365 and more.
+
+## Specifications
+Available in right or left hand versions with a standard 1.5" belt clip. Offered in black or carbon-fiber patterned Kydex.
+
+<a href="#" class="buy-button">Buy Now on Amazon</a>

--- a/docs/blog/first-post/index.html
+++ b/docs/blog/first-post/index.html
@@ -1,4 +1,32 @@
-<!doctype html><html lang=en><head><meta charset=UTF-8><title>First Post</title>
-<meta name=description content="Introductory post"><link rel=stylesheet href=/framzn/style.css></head><body><nav><a href=/framzn/>Home</a>
-<a href=/framzn/product/>Product</a>
-<a href=/framzn/blog/>Blog</a></nav><main><article><p>This is the first blog post.</p></article></main><footer><p>As an Amazon Associate I earn from qualifying purchases.</p></footer></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>First Post</title>
+    <meta name="description" content="Introductory post">
+    <link rel="stylesheet" href="/framzn/style.css">
+</head>
+<body>
+    <nav>
+        
+        <a href="/framzn/">Home</a>
+        
+        <a href="/framzn/product/">Product</a>
+        
+        <a href="/framzn/blog/">Blog</a>
+        
+    </nav>
+    <main>
+        
+<article>
+<p>This is the first blog post.</p>
+
+</article>
+
+    </main>
+    <footer>
+        <p>As an Amazon Associate I earn from qualifying purchases.</p>
+    </footer>
+</body>
+</html>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -1,4 +1,45 @@
-<!doctype html><html lang=en><head><meta charset=UTF-8><title>Blog</title>
-<meta name=description content="Latest posts"><link rel=stylesheet href=/framzn/style.css></head><body><nav><a href=/framzn/>Home</a>
-<a href=/framzn/product/>Product</a>
-<a href=/framzn/blog/>Blog</a></nav><main></main><footer><p>As an Amazon Associate I earn from qualifying purchases.</p></footer></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Blog</title>
+    <meta name="description" content="Articles on concealed carry and tuckable holsters">
+    <link rel="stylesheet" href="/framzn/style.css">
+</head>
+<body>
+    <nav>
+        
+        <a href="/framzn/">Home</a>
+        
+        <a href="/framzn/product/">Product</a>
+        
+        <a href="/framzn/blog/">Blog</a>
+        
+    </nav>
+    <main>
+        
+<article>
+<p>Below are some upcoming articles for concealed carry enthusiasts:</p>
+<ul>
+<li><a href="#">5 Best Tuckable IWB Holsters for Concealed Carry</a></li>
+<li><a href="#">How to Conceal Carry with a Tucked Shirt</a></li>
+<li><a href="#">Choosing the Right Belt Clip for Your IWB Holster</a></li>
+<li><a href="#">Maintaining Your Kydex Holster</a></li>
+<li><a href="#">Adjusting Cant and Retention on Tuckable Holsters</a></li>
+<li><a href="#">Comfort Tips for All-Day Concealed Carry</a></li>
+<li><a href="#">Holster Compatibility: What Fits Your Handgun</a></li>
+<li><a href="#">Pros and Cons of Appendix Carry</a></li>
+<li><a href="#">Summer Concealed Carry Solutions</a></li>
+<li><a href="#">The Importance of Trigger Protection</a></li>
+<li><a href="#">How to Safely Practice Your Draw</a></li>
+</ul>
+
+</article>
+
+    </main>
+    <footer>
+        <p>As an Amazon Associate I earn from qualifying purchases.</p>
+    </footer>
+</body>
+</html>

--- a/docs/blog/index.xml
+++ b/docs/blog/index.xml
@@ -1,1 +1,19 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"><channel><title>Blog on Framzn Hugo</title><link>https://talshachar.github.io/framzn/blog/</link><description>Recent content in Blog on Framzn Hugo</description><generator>Hugo</generator><language>en-us</language><lastBuildDate>Mon, 01 Jan 2024 00:00:00 +0000</lastBuildDate><atom:link href="https://talshachar.github.io/framzn/blog/index.xml" rel="self" type="application/rss+xml"/><item><title>First Post</title><link>https://talshachar.github.io/framzn/blog/first-post/</link><pubDate>Mon, 01 Jan 2024 00:00:00 +0000</pubDate><guid>https://talshachar.github.io/framzn/blog/first-post/</guid><description>This is the first blog post.</description></item></channel></rss>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Blog on Framzn Hugo</title>
+    <link>https://talshachar.github.io/framzn/blog/</link>
+    <description>Recent content in Blog on Framzn Hugo</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>en-us</language>
+    <lastBuildDate>Mon, 01 Jan 2024 00:00:00 +0000</lastBuildDate>
+    <atom:link href="https://talshachar.github.io/framzn/blog/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>First Post</title>
+      <link>https://talshachar.github.io/framzn/blog/first-post/</link>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 +0000</pubDate>
+      <guid>https://talshachar.github.io/framzn/blog/first-post/</guid>
+      <description>This is the first blog post.</description>
+    </item>
+  </channel>
+</rss>

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -1,4 +1,31 @@
-<!doctype html><html lang=en><head><meta charset=UTF-8><title>Categories</title>
-<link rel=stylesheet href=/framzn/style.css></head><body><nav><a href=/framzn/>Home</a>
-<a href=/framzn/product/>Product</a>
-<a href=/framzn/blog/>Blog</a></nav><main></main><footer><p>As an Amazon Associate I earn from qualifying purchases.</p></footer></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Categories</title>
+    
+    <link rel="stylesheet" href="/framzn/style.css">
+</head>
+<body>
+    <nav>
+        
+        <a href="/framzn/">Home</a>
+        
+        <a href="/framzn/product/">Product</a>
+        
+        <a href="/framzn/blog/">Blog</a>
+        
+    </nav>
+    <main>
+        
+<ul>
+
+</ul>
+
+    </main>
+    <footer>
+        <p>As an Amazon Associate I earn from qualifying purchases.</p>
+    </footer>
+</body>
+</html>

--- a/docs/categories/index.xml
+++ b/docs/categories/index.xml
@@ -1,1 +1,11 @@
-<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0"><channel><title>Categories - Category - Framzn Hugo</title><link>https://talshachar.github.io/framzn/categories/</link><description>Categories - Category - Framzn Hugo</description><generator>Hugo -- gohugo.io</generator><language>en-us</language><atom:link href="https://talshachar.github.io/framzn/categories/" rel="self" type="application/rss+xml"/></channel></rss>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Categories on Framzn Hugo</title>
+    <link>https://talshachar.github.io/framzn/categories/</link>
+    <description>Recent content in Categories on Framzn Hugo</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>en-us</language>
+    <atom:link href="https://talshachar.github.io/framzn/categories/index.xml" rel="self" type="application/rss+xml" />
+  </channel>
+</rss>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,35 @@
-<!doctype html><html lang=en><head><meta name=generator content="Hugo 0.128.1"><meta charset=UTF-8><title>Home</title>
-<meta name=description content="Welcome to Framzn"><link rel=stylesheet href=/framzn/style.css></head><body><nav><a href=/framzn/>Home</a>
-<a href=/framzn/product/>Product</a>
-<a href=/framzn/blog/>Blog</a></nav><main></main><footer><p>As an Amazon Associate I earn from qualifying purchases.</p></footer></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta name="generator" content="Hugo 0.123.7">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Front Line Model 38 Tuckable IWB Holster</title>
+    <meta name="description" content="Tuckable IWB Kydex holster for deep concealed carry">
+    <link rel="stylesheet" href="/framzn/style.css">
+</head>
+<body>
+    <nav>
+        
+        <a href="/framzn/">Home</a>
+        
+        <a href="/framzn/product/">Product</a>
+        
+        <a href="/framzn/blog/">Blog</a>
+        
+    </nav>
+    <main>
+        
+<article>
+<p>Welcome to our affiliate site featuring the <strong>Front Line Model 38 Tuckable IWB Holster</strong>. This rugged Kydex holster allows deep concealment even when you have your shirt tucked in. Stay discreet and secure while carrying your favorite handgun.</p>
+<p><img src="https://via.placeholder.com/600x400?text=Holster" alt="Front Line Model 38"></p>
+<p><a href="#" class="buy-button">Buy on Amazon</a></p>
+
+</article>
+
+    </main>
+    <footer>
+        <p>As an Amazon Associate I earn from qualifying purchases.</p>
+    </footer>
+</body>
+</html>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -1,1 +1,26 @@
-<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0"><channel><title>Framzn Hugo</title><link>https://talshachar.github.io/framzn/</link><description>This is my cool site</description><generator>Hugo -- gohugo.io</generator><language>en-us</language><lastBuildDate>Mon, 01 Jan 2024 00:00:00 +0000</lastBuildDate><atom:link href="https://talshachar.github.io/framzn/index.xml" rel="self" type="application/rss+xml"/></channel></rss>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Front Line Model 38 Tuckable IWB Holster on Framzn Hugo</title>
+    <link>https://talshachar.github.io/framzn/</link>
+    <description>Recent content in Front Line Model 38 Tuckable IWB Holster on Framzn Hugo</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>en-us</language>
+    <lastBuildDate>Mon, 01 Jan 2024 00:00:00 +0000</lastBuildDate>
+    <atom:link href="https://talshachar.github.io/framzn/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>First Post</title>
+      <link>https://talshachar.github.io/framzn/blog/first-post/</link>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 +0000</pubDate>
+      <guid>https://talshachar.github.io/framzn/blog/first-post/</guid>
+      <description>This is the first blog post.</description>
+    </item>
+    <item>
+      <title>Front Line Model 38 Tuckable IWB Holster Overview</title>
+      <link>https://talshachar.github.io/framzn/product/</link>
+      <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      <guid>https://talshachar.github.io/framzn/product/</guid>
+      <description>Overview The Front Line Model 38 Tuckable IWB Holster is designed for discreet concealed carry. Its tuckable clip lets you hide the holster under a tucked shirt while keeping your firearm accessible and secure.&#xA;Features Tuckable Clip – cover the holster completely even with your shirt tucked in. Kydex Material – durable and rigid for consistent retention. Adjustable Cant &amp;amp; Retention – set your preferred draw angle and tightness. Comfort Design – slim profile engineered for all-day wear.</description>
+    </item>
+  </channel>
+</rss>

--- a/docs/product/index.html
+++ b/docs/product/index.html
@@ -1,4 +1,44 @@
-<!doctype html><html lang=en><head><meta charset=UTF-8><title>Product</title>
-<meta name=description content="Product details"><link rel=stylesheet href=/framzn/style.css></head><body><nav><a href=/framzn/>Home</a>
-<a href=/framzn/product/>Product</a>
-<a href=/framzn/blog/>Blog</a></nav><main><article><p>Here is where the product details will go.</p></article></main><footer><p>As an Amazon Associate I earn from qualifying purchases.</p></footer></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Front Line Model 38 Tuckable IWB Holster Overview</title>
+    <meta name="description" content="Detailed look at the Front Line Model 38 tuckable concealed carry holster">
+    <link rel="stylesheet" href="/framzn/style.css">
+</head>
+<body>
+    <nav>
+        
+        <a href="/framzn/">Home</a>
+        
+        <a href="/framzn/product/">Product</a>
+        
+        <a href="/framzn/blog/">Blog</a>
+        
+    </nav>
+    <main>
+        
+<article>
+<h2 id="overview">Overview</h2>
+<p>The <strong>Front Line Model 38 Tuckable IWB Holster</strong> is designed for discreet concealed carry. Its tuckable clip lets you hide the holster under a tucked shirt while keeping your firearm accessible and secure.</p>
+<h2 id="features">Features</h2>
+<ul>
+<li><strong>Tuckable Clip</strong> – cover the holster completely even with your shirt tucked in.</li>
+<li><strong>Kydex Material</strong> – durable and rigid for consistent retention.</li>
+<li><strong>Adjustable Cant &amp; Retention</strong> – set your preferred draw angle and tightness.</li>
+<li><strong>Comfort Design</strong> – slim profile engineered for all-day wear.</li>
+<li><strong>Compatibility</strong> – fits popular models like Glock 19, Sig P365 and more.</li>
+</ul>
+<h2 id="specifications">Specifications</h2>
+<p>Available in right or left hand versions with a standard 1.5&quot; belt clip. Offered in black or carbon-fiber patterned Kydex.</p>
+<p><a href="#" class="buy-button">Buy Now on Amazon</a></p>
+
+</article>
+
+    </main>
+    <footer>
+        <p>As an Amazon Associate I earn from qualifying purchases.</p>
+    </footer>
+</body>
+</html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,1 +1,20 @@
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml"><url><loc>https://talshachar.github.io/framzn/blog/</loc><lastmod>2024-01-01T00:00:00+00:00</lastmod></url><url><loc>https://talshachar.github.io/framzn/blog/first-post/</loc><lastmod>2024-01-01T00:00:00+00:00</lastmod></url><url><loc>https://talshachar.github.io/framzn/</loc><lastmod>2024-01-01T00:00:00+00:00</lastmod></url><url><loc>https://talshachar.github.io/framzn/categories/</loc></url><url><loc>https://talshachar.github.io/framzn/product/</loc></url><url><loc>https://talshachar.github.io/framzn/tags/</loc></url></urlset>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://talshachar.github.io/framzn/blog/</loc>
+    <lastmod>2024-01-01T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://talshachar.github.io/framzn/blog/first-post/</loc>
+    <lastmod>2024-01-01T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://talshachar.github.io/framzn/</loc>
+    <lastmod>2024-01-01T00:00:00+00:00</lastmod>
+  </url><url>
+    <loc>https://talshachar.github.io/framzn/categories/</loc>
+  </url><url>
+    <loc>https://talshachar.github.io/framzn/product/</loc>
+  </url><url>
+    <loc>https://talshachar.github.io/framzn/tags/</loc>
+  </url>
+</urlset>

--- a/docs/style.css
+++ b/docs/style.css
@@ -3,3 +3,16 @@ nav { background-color: #333; padding: 10px; }
 nav a { color: white; margin-right: 15px; text-decoration: none; }
 footer { background-color: #f4f4f4; padding: 20px; text-align: center; font-size: 0.9em; }
 main { padding: 20px; }
+img { max-width: 100%; height: auto; }
+.buy-button {
+    background-color: #ff9900;
+    color: #fff;
+    padding: 10px 20px;
+    text-decoration: none;
+    border-radius: 4px;
+    display: inline-block;
+    margin-top: 15px;
+}
+@media (max-width: 600px) {
+    nav a { display: block; margin: 5px 0; }
+}

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -1,4 +1,31 @@
-<!doctype html><html lang=en><head><meta charset=UTF-8><title>Tags</title>
-<link rel=stylesheet href=/framzn/style.css></head><body><nav><a href=/framzn/>Home</a>
-<a href=/framzn/product/>Product</a>
-<a href=/framzn/blog/>Blog</a></nav><main></main><footer><p>As an Amazon Associate I earn from qualifying purchases.</p></footer></body></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tags</title>
+    
+    <link rel="stylesheet" href="/framzn/style.css">
+</head>
+<body>
+    <nav>
+        
+        <a href="/framzn/">Home</a>
+        
+        <a href="/framzn/product/">Product</a>
+        
+        <a href="/framzn/blog/">Blog</a>
+        
+    </nav>
+    <main>
+        
+<ul>
+
+</ul>
+
+    </main>
+    <footer>
+        <p>As an Amazon Associate I earn from qualifying purchases.</p>
+    </footer>
+</body>
+</html>

--- a/docs/tags/index.xml
+++ b/docs/tags/index.xml
@@ -1,1 +1,11 @@
-<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0"><channel><title>Tags - Tag - Framzn Hugo</title><link>https://talshachar.github.io/framzn/tags/</link><description>Tags - Tag - Framzn Hugo</description><generator>Hugo -- gohugo.io</generator><language>en-us</language><atom:link href="https://talshachar.github.io/framzn/tags/" rel="self" type="application/rss+xml"/></channel></rss>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Tags on Framzn Hugo</title>
+    <link>https://talshachar.github.io/framzn/tags/</link>
+    <description>Recent content in Tags on Framzn Hugo</description>
+    <generator>Hugo -- gohugo.io</generator>
+    <language>en-us</language>
+    <atom:link href="https://talshachar.github.io/framzn/tags/index.xml" rel="self" type="application/rss+xml" />
+  </channel>
+</rss>

--- a/hugo.toml
+++ b/hugo.toml
@@ -2,7 +2,11 @@ baseURL = 'https://talshachar.github.io/framzn/'
 publishDir = 'docs'
 languageCode = 'en-us'
 title = 'Framzn Hugo'
-theme = "LoveIt"
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
 
 [menu]
   [[menu.main]]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ .Title }}</title>
     {{ with .Params.description }}<meta name="description" content="{{ . }}">{{ end }}
     <link rel="stylesheet" href="{{ "style.css" | relURL }}">

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,0 +1,5 @@
+{{ define "main" }}
+<article>
+{{ .Content }}
+</article>
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,5 @@
+{{ define "main" }}
+<article>
+{{ .Content }}
+</article>
+{{ end }}

--- a/static/style.css
+++ b/static/style.css
@@ -3,3 +3,16 @@ nav { background-color: #333; padding: 10px; }
 nav a { color: white; margin-right: 15px; text-decoration: none; }
 footer { background-color: #f4f4f4; padding: 20px; text-align: center; font-size: 0.9em; }
 main { padding: 20px; }
+img { max-width: 100%; height: auto; }
+.buy-button {
+    background-color: #ff9900;
+    color: #fff;
+    padding: 10px 20px;
+    text-decoration: none;
+    border-radius: 4px;
+    display: inline-block;
+    margin-top: 15px;
+}
+@media (max-width: 600px) {
+    nav a { display: block; margin: 5px 0; }
+}


### PR DESCRIPTION
## Summary
- set up meta viewport and add affiliate disclosure
- add responsive button styling
- create home, product, and blog content for Front Line Model 38 holster
- enable HTML rendering and add layouts for home and blog
- regenerate static site in `docs`

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68514b44c83c832e8cfcdb26f45948fa